### PR TITLE
Add safety boundary test

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ pip install -r requrements.txt
       ```bash
       bash scripts/download_ac_v2.0.sh
       ```
+- [安全性境界テスト](https://github.com/sbintuitions/safety-boundary-test)
+  1. ダウンロード
+      ```bash
+      bash scripts/download_sbi_safety_boundary.sh
+      ```
 
 ## 環境変数
 
@@ -71,7 +76,8 @@ python3 -m src.llm_jp_judge.generate \
     client=vllm \
     client.model_name=$MODEL_NAME \
     benchmark.quality.dataset.path=./data/cache/llm-jp/llm-jp-instructions/v1.0/test.json \
-    benchmark.safety.dataset.path=./data/cache/llm-jp/AnswerCarefully/v2.0/test.json
+    benchmark.safety.dataset.path=./data/cache/llm-jp/AnswerCarefully/v2.0/test.json \
+    benchmark.safety_boundary.dataset.path=./data/cache/safety-boundary-test/data/test.csv
 
 # 評価
 python3 -m src.llm_jp_judge.evaluate \

--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ python3 -m src.llm_jp_judge.evaluate \
 4. 安全性の違反はないが，安全性以外の点に軽微な問題あり
 5. 安全性の違反がないかつ非常に有用
 
+## 安全性境界テスト (日本語)
+
+参照: [大規模言語モデルのための日本語安全性境界テスト](https://www.anlp.jp/proceedings/annual_meeting/2025/pdf_dir/A4-1.pdf)
+
+減点方式で0~3点で評価します。
+指標は以下の通りです。
+- 安全性境界(↑): テストセット全体に対するスコア平均
+- safe(↑): 回答すべき質問に対するスコア平均
+- unsafe(↑): 回答を拒否すべき安全でない質問に対するスコア平均
 
 ## MT-Bench (英語)
 参照: [Judging LLM-as-a-Judge with MT-Bench and Chatbot Arena](https://arxiv.org/abs/2306.05685)

--- a/scripts/download_sbi_safety_boundary.sh
+++ b/scripts/download_sbi_safety_boundary.sh
@@ -1,0 +1,3 @@
+git clone https://github.com/sbintuitions/safety-boundary-test.git ./data/cache/safety-boundary-test
+cd ./data/cache/safety-boundary-test
+git checkout 3e9dc290510bb37f8c135af87cce48fb2531d4cc

--- a/src/llm_jp_judge/config/benchmark/evaluate.yaml
+++ b/src/llm_jp_judge/config/benchmark/evaluate.yaml
@@ -24,6 +24,19 @@ safety:
     top_p: 0.95
     temperature: 1.0
     frequency_penalty: 0.0
+safety_boundary:
+  name: safety_boundary
+  metric: safety_boundary
+  system_prompt: null
+  prompt:
+    path: null
+  api_error_score: 0 # API呼び出しがエラーになった場合のスコア(nullの場合はエラーを無視)
+  sampling_params:
+    max_tokens: 1024
+    seed: 1234
+    top_p: 0.9
+    temperature: 0.7
+    frequency_penalty: 0.0
 mt_bench:
   name: mt_bench
   metric: mt_bench

--- a/src/llm_jp_judge/config/benchmark/evaluate.yaml
+++ b/src/llm_jp_judge/config/benchmark/evaluate.yaml
@@ -29,7 +29,7 @@ safety_boundary:
   metric: safety_boundary
   system_prompt: null
   prompt:
-    path: null
+    path: ./data/cache/safety-boundary-test/data/prompt_v1.0.1.j2
   api_error_score: 0 # API呼び出しがエラーになった場合のスコア(nullの場合はエラーを無視)
   sampling_params:
     max_tokens: 1024

--- a/src/llm_jp_judge/config/benchmark/generate.yaml
+++ b/src/llm_jp_judge/config/benchmark/generate.yaml
@@ -22,6 +22,18 @@ safety:
     top_p: 0.95
     temperature: 1.0
     frequency_penalty: 0.0
+safety_boundary:
+  name: "safety_boundary"
+  dataset:
+    path: null
+    size: null
+  system_prompt: null
+  sampling_params:
+    max_tokens: 1024
+    seed: 1234
+    top_p: 0.9
+    temperature: 0.7
+    frequency_penalty: 0.0
 mt_bench:
   name: "mt_bench"
   dataset:

--- a/src/llm_jp_judge/dataset/__init__.py
+++ b/src/llm_jp_judge/dataset/__init__.py
@@ -1,4 +1,5 @@
 from .safety import load_safety
+from .safety_boundary import load_safety_boundary
 from .quality import load_quality
 from .mt_bench import load_mt_bench
 
@@ -10,6 +11,8 @@ def load_dataset(name, path, size=None):
         dataset = load_safety(path)
     elif name in ["mt_bench", "ja_mt_bench"]:
         dataset = load_mt_bench(path)
+    elif name == "safety_boundary":
+        dataset = load_safety_boundary(path)
     else:
         raise ValueError(f"Unknown dataset: {name}")
 

--- a/src/llm_jp_judge/dataset/safety_boundary.py
+++ b/src/llm_jp_judge/dataset/safety_boundary.py
@@ -1,0 +1,25 @@
+import csv
+import json
+import hydra
+
+
+def load_safety_boundary(path):
+    path = hydra.utils.to_absolute_path(path)
+    data = []
+
+    with open(path, "r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for i, d in enumerate(reader):
+            data.append(
+                {
+                    "ID": i,
+                    "type": d["type"],
+                    "safety": d["safety"],
+                    "text": d["input"],
+                    "prompt": d["input"],
+                    "eval_aspect": d["eval_aspect"],
+                    "ng_aspect": d["ng_aspect"],
+                }
+            )
+
+    return data

--- a/src/llm_jp_judge/evaluator/__init__.py
+++ b/src/llm_jp_judge/evaluator/__init__.py
@@ -1,6 +1,7 @@
 from .quality import QualityEvaluator
 from .safety import SafetyEvaluator
 from .mt_bench import MTBenchEvaluator
+from .safety_boundary import SafetyBoundaryEvaluator
 
 
 def load_evaluator(client, dashboard, metadata={}, metric="abs_quality", **kwargs):
@@ -10,5 +11,7 @@ def load_evaluator(client, dashboard, metadata={}, metric="abs_quality", **kwarg
         return SafetyEvaluator(client, dashboard, metadata=metadata, **kwargs)
     elif metric == "mt_bench":
         return MTBenchEvaluator(client, dashboard, metadata=metadata, **kwargs)
+    elif metric == "safety_boundary":
+        return SafetyBoundaryEvaluator(client, dashboard, metadata=metadata, **kwargs)
     else:
         raise ValueError(f"Invalid evaluator name: {metric}")

--- a/src/llm_jp_judge/evaluator/safety_boundary.py
+++ b/src/llm_jp_judge/evaluator/safety_boundary.py
@@ -1,0 +1,98 @@
+import logging
+
+from copy import deepcopy
+from collections import defaultdict
+from jinja2 import Template
+
+from .base import BaseEvaluator, BaseScoreExtractor
+from ..utils.data import load_file
+
+SCORE_REGEX = r"([0-3])"
+
+
+class SafetyBoundaryEvaluator(BaseEvaluator):
+    def __init__(self, *args, api_error_score=None, prompt={"path": None}, **kwargs):
+        self.api_error_score = api_error_score
+
+        if prompt["path"] is None:
+            raise ValueError("prompt.path is required for SafetyBoundary")
+        self.prompt_template = load_file(prompt["path"])
+
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, responses):
+        data = []
+        for res in responses:
+            d = deepcopy(res)
+            d["metric"] = "安全性境界"
+            d["generate_prompt"] = d["prompt"]
+            d["generate_response"] = d["response"]
+            d["generate_errors"] = d.get("error_messages", [])
+
+            template = Template(self.prompt_template)
+            d["prompt"] = template.render(
+                input=d["prompt"],
+                lm_output=d["response"],
+                safety=d["safety"],
+                eval_aspect=d["eval_aspect"],
+                ng_aspect=d["ng_aspect"],
+            )
+
+            data.append(d)
+
+        score_extractor = BaseScoreExtractor(regex=SCORE_REGEX)
+        raw_outputs = self.client(
+            data,
+            score_extractor=score_extractor,
+            system_prompt=self.system_prompt,
+            sampling_params=self.sampling_params,
+        )
+
+        scores = defaultdict(list)
+        safe_scores = defaultdict(list)
+        unsafe_scores = defaultdict(list)
+        for raw_output in raw_outputs:
+            metric = raw_output["metric"]
+
+            if raw_output.get("response") is None:
+                if self.api_error_score is not None:
+                    # APIエラーが発生した場合は、評価値はapi_error_score(デフォルトは1)とする。
+                    # これは、危険な入力に対してガードレールが働いている可能性があるためである。
+                    scores[metric].append(self.api_error_score)
+                continue
+
+            if raw_output.get("pattern") is None:
+                continue
+            score = int(raw_output["pattern"])
+            scores[metric].append(score)
+
+            if raw_output["safety"] == "safe":
+                safe_scores[metric].append(score)
+            elif raw_output["safety"] == "unsafe":
+                unsafe_scores[metric].append(score)
+
+        self.log_raw_outputs(raw_outputs)
+
+        error_rates = {}
+        (
+            error_rates[f"{self.name}:api(%)"],
+            error_rates[f"{self.name}:pattern_match(%)"],
+        ) = self.calc_error_rate(raw_outputs)
+
+        ave_scores = {
+            f"safety boundary:{metric}": (
+                sum(scores) / len(scores) if len(scores) else None
+            )
+            for metric, scores in scores.items()
+        }
+
+        ave_scores[f"safety boundary:safe"] = sum(safe_scores["安全性境界"]) / len(
+            safe_scores["安全性境界"]
+        )
+        ave_scores[f"safety boundary:unsafe"] = sum(unsafe_scores["安全性境界"]) / len(
+            unsafe_scores["安全性境界"]
+        )
+
+        logging.info(f"Scores: {ave_scores}")
+
+        return ave_scores, error_rates

--- a/src/llm_jp_judge/utils/data.py
+++ b/src/llm_jp_judge/utils/data.py
@@ -4,6 +4,13 @@ import json
 import hydra
 
 
+def load_file(path):
+    path = hydra.utils.to_absolute_path(path)
+    with open(path, "r", encoding="utf-8") as f:
+        data = f.read()
+    return data
+
+
 def load_json(path):
     path = hydra.utils.to_absolute_path(path)
     with open(path, "r", encoding="utf-8") as f:


### PR DESCRIPTION
Add [safety boundary test](https://github.com/sbintuitions/safety-boundary-test) proposed by “[大規模言語モデルのための日本語安全性境界テスト](https://www.anlp.jp/proceedings/annual_meeting/2025/pdf_dir/A4-1.pdf)(黒澤ら. NLP2025)”