### PR TITLE
Fix client.max_retries

### DIFF
--- a/src/llm_jp_judge/client/local.py
+++ b/src/llm_jp_judge/client/local.py
@@ -46,7 +46,7 @@ class vLLMClient(BaseClient):
         tokenizer_name=None,
         batch_size=1,
         download_dir="~/.cache/huggingface",
-        max_retries=1,
+        max_retries=3,
         chat_template={"path": None},
         disable_system_prompt=False,
         **init_kwargs,
@@ -121,7 +121,7 @@ class vLLMClient(BaseClient):
 
         retry_count = 0
         done_indices = set()
-        while retry_count < self.max_retries and len(pending_indices) > 0:
+        while retry_count <= self.max_retries and len(pending_indices) > 0:
             responses = self.batch_request(
                 [data[i]["prompt"][: turn + 1] for i in pending_indices],
                 [data[i]["response"][:turn] for i in pending_indices],

--- a/src/llm_jp_judge/client/remote.py
+++ b/src/llm_jp_judge/client/remote.py
@@ -116,7 +116,7 @@ class OpenAI(BaseClient):
             d["response"].append(None)
             d["pattern"].append(None)
             d["error_messages"].append([])
-            while retry_count < self.max_retries:
+            while retry_count <= self.max_retries:
                 if len(d["error_messages"][-1]) > 0:
                     logging.warning(
                         f"{d['error_messages'][-1][-1]}. Retrying in {sleep} seconds."

--- a/src/llm_jp_judge/config/client/vllm.yaml
+++ b/src/llm_jp_judge/config/client/vllm.yaml
@@ -31,6 +31,7 @@ download_dir: ./data/cache
 chat_template:
   path: null
 
+max_retries: 3
 batch_size: 1
 disable_system_prompt: false # システムプロンプトが無効になります。システムプロンプトが与えられた場合、ユーザープロンプトの先頭に結合されます。
 


### PR DESCRIPTION
- vllm使用時にもclient.max_retriesを指定可能に修正
- client.max_retriesで指定した回数リトライが走るよう修正(今まではclient.max_retries-1回になっていた)