### PR TITLE
ログに最終的なスコアを追加

### DIFF
--- a/src/llm_jp_judge/evaluator/base.py
+++ b/src/llm_jp_judge/evaluator/base.py
@@ -40,7 +40,8 @@ class BaseEvaluator:
             "metric",
             "evaluation prompt",
             "evaluation response",
-            "score",
+            "pattern",
+            "score",            
             "generate errors",
             "evaluation errors",
         ]
@@ -51,6 +52,7 @@ class BaseEvaluator:
                 score["prompt"],
                 score["response"],
                 score["pattern"],
+                score["score"],
                 json.dumps(score["generate_errors"]),
                 json.dumps(score["error_messages"]),
             ]

--- a/src/llm_jp_judge/evaluator/culture.py
+++ b/src/llm_jp_judge/evaluator/culture.py
@@ -88,12 +88,6 @@ class CultureEvaluator(BaseEvaluator):
                     raw_score["score"] = int(self.api_error_score)
                 continue
 
-            if raw_score.get("generate_response") is None or raw_score.get("generate_response") == "":
-                if self.empty_response_score is not None:
-                    # 評価対象の応答が空の場合は、評価値はempty_response_score(デフォルトは1)とする。
-                    raw_score["score"] = int(self.empty_response_score)
-                continue
-
             if raw_score.get("pattern") is None:
                 raw_score["score"] = None
                 continue

--- a/src/llm_jp_judge/evaluator/mt_bench.py
+++ b/src/llm_jp_judge/evaluator/mt_bench.py
@@ -82,20 +82,20 @@ class MTBenchEvaluator(BaseEvaluator):
         return query
 
     def calc_score(self, raw_outputs):
-        raw_outputs = [r for r in raw_outputs if r.get("pattern") is not None]
+        raw_outputs = [r for r in raw_outputs if r.get("score") is not None]
 
         # Evaluate average score
-        ave_score = sum([int(r["pattern"]) for r in raw_outputs]) / len(raw_outputs)
+        ave_score = sum([r["score"] for r in raw_outputs]) / len(raw_outputs)
         logging.info(f"Average score: {ave_score:.2f}")
 
         # Evaluate turn-wise scores
         t1_raw_outputs = [r for r in raw_outputs if r["turn"] == 1]
         t2_raw_outputs = [r for r in raw_outputs if r["turn"] == 2]
 
-        t1_score = sum([int(r["pattern"]) for r in t1_raw_outputs]) / len(
+        t1_score = sum([r["score"] for r in t1_raw_outputs]) / len(
             t1_raw_outputs
         )
-        t2_score = sum([int(r["pattern"]) for r in t2_raw_outputs]) / len(
+        t2_score = sum([r["score"] for r in t2_raw_outputs]) / len(
             t2_raw_outputs
         )
 
@@ -146,6 +146,7 @@ class MTBenchEvaluator(BaseEvaluator):
             "system prompt",
             "prompt",
             "response",
+            "pattern",
             "score",
             "generate errors",
             "evaluation errors",
@@ -161,6 +162,7 @@ class MTBenchEvaluator(BaseEvaluator):
                 score["prompt"],
                 score["response"],
                 score["pattern"],
+                score["score"],
                 json.dumps(score["generate_errors"], ensure_ascii=False),
                 json.dumps(score["error_messages"], ensure_ascii=False),
             ]
@@ -209,6 +211,13 @@ class MTBenchEvaluator(BaseEvaluator):
         # Multi-turn evaluation
         raw_outputs += self.evaluate(questions, use_reference=False, multi_turn=True)
         raw_outputs += self.evaluate(questions_ref, use_reference=True, multi_turn=True)
+
+        # Calculate final scores
+        for raw_output in raw_outputs:
+            if raw_output.get("pattern") is None:
+                raw_output["score"] = None
+                continue
+            raw_output["score"] = int(raw_output["pattern"])
 
         self.log_raw_outputs(raw_outputs)
 

--- a/src/llm_jp_judge/evaluator/quality.py
+++ b/src/llm_jp_judge/evaluator/quality.py
@@ -115,6 +115,12 @@ class QualityEvaluator(BaseEvaluator):
             sampling_params=self.sampling_params,
         )
 
+        error_rates = {}
+        (
+            error_rates[f"{self.name}:api(%)"],
+            error_rates[f"{self.name}:pattern_match(%)"],
+        ) = self.calc_error_rate(raw_outputs)
+
         # 最終スコアの計算
         for raw_output in raw_outputs:
             raw_output["score"] = {}
@@ -132,12 +138,6 @@ class QualityEvaluator(BaseEvaluator):
             for metric in METRICS:
                 if raw_output["score"][metric] is not None:
                     scores[metric].append(raw_output["score"][metric])
-
-        error_rates = {}
-        (
-            error_rates[f"{self.name}:api(%)"],
-            error_rates[f"{self.name}:pattern_match(%)"],
-        ) = self.calc_error_rate(raw_outputs)
 
         ave_scores = {
             f"quality:{metric}": sum(scores) / len(scores) if len(scores) else None

--- a/src/llm_jp_judge/evaluator/safety.py
+++ b/src/llm_jp_judge/evaluator/safety.py
@@ -87,6 +87,12 @@ class SafetyEvaluator(BaseEvaluator):
             sampling_params=self.sampling_params,
         )
 
+        error_rates = {}
+        (
+            error_rates[f"{self.name}:api(%)"],
+            error_rates[f"{self.name}:pattern_match(%)"],
+        ) = self.calc_error_rate(raw_outputs)
+
         # 最終スコアの計算
         for raw_output in raw_outputs:
             if raw_output.get("response") is None:
@@ -112,12 +118,6 @@ class SafetyEvaluator(BaseEvaluator):
             scores[metric].append(raw_output["score"])
 
         self.log_raw_outputs(raw_outputs)
-
-        error_rates = {}
-        (
-            error_rates[f"{self.name}:api(%)"],
-            error_rates[f"{self.name}:pattern_match(%)"],
-        ) = self.calc_error_rate(raw_outputs)
 
         ave_scores = {
             f"safety:{metric}": sum(scores) / len(scores) if len(scores) else None


### PR DESCRIPTION
モデルにより得られたスコアに対して、`api_error_score`や`empty_response_score`を反映したスコアを`score`として、`*_raw_output_table.json`に保存するよう修正。  
v1.0.0で保存されていた`score`は`pattern`として保存される。