### PR TITLE
スコア抽出失敗時に例外を発生させるよう修正

### DIFF
--- a/src/llm_jp_judge/client/remote.py
+++ b/src/llm_jp_judge/client/remote.py
@@ -14,6 +14,7 @@ import tqdm
 import tqdm.asyncio
 
 from .local import BaseClient
+from ..evaluator.base import ScoreExtractionError
 
 load_dotenv(override=True)
 
@@ -143,7 +144,7 @@ class OpenAI(BaseClient):
                     if score_extractor is not None:
                         try:
                             d["pattern"][-1] = score_extractor(d["response"][-1])
-                        except Exception as e:
+                        except ScoreExtractionError as e:
                             d["error_messages"][-1].append(str(e))
                             retry_count += 1
                             sleep = self.async_request_interval

--- a/src/llm_jp_judge/evaluator/base.py
+++ b/src/llm_jp_judge/evaluator/base.py
@@ -2,6 +2,9 @@ import re
 import json
 import logging
 
+class ScoreExtractionError(Exception):
+    pass
+
 
 class BaseScoreExtractor(object):
     def __init__(self, regex):
@@ -9,7 +12,9 @@ class BaseScoreExtractor(object):
 
     def __call__(self, text):
         m = re.search(self.regex, text)
-        return m.group(1) if m else None
+        if m is None:
+            raise ScoreExtractionError(f"Regex '{self.regex}' did not match.")
+        return m.group(1)
 
 
 class BaseEvaluator:

--- a/src/llm_jp_judge/evaluator/quality.py
+++ b/src/llm_jp_judge/evaluator/quality.py
@@ -5,7 +5,7 @@ import logging
 from copy import deepcopy
 from collections import defaultdict
 
-from .base import BaseEvaluator
+from .base import BaseEvaluator, ScoreExtractionError
 
 PROMPT_TEMPLATE = """[指示]
 質問に対するAIアシスタントの回答を以下の基準で評価してください。
@@ -55,11 +55,11 @@ class QualityScoreExtractor(object):
         scores = {}
         for metric, score in re.findall(self.regex, text):
             if metric in scores:
-                raise ValueError("Duplicate metric")
+                raise ScoreExtractionError("Duplicate metric")
             scores[metric] = int(score)
 
         if set(scores.keys()) != set(METRICS):
-            raise ValueError("Invalid score format")
+            raise ScoreExtractionError("Invalid score format")
 
         return scores
 


### PR DESCRIPTION
`BaseScoreExtractor`でのスコア抽出失敗時に`ScoreExtractionError`を発生させるよう修正。  
`v1.0.0`と比較して、`mt_bench`、`ja_mt_bench`、`safety`スコアに軽微な影響あり。  
(`quality`は元から例外を発生させていたため影響なし。)