### PR TITLE
日本文化評価からapi_error_scoreの除外

### DIFF
--- a/src/llm_jp_judge/config/benchmark/evaluate.yaml
+++ b/src/llm_jp_judge/config/benchmark/evaluate.yaml
@@ -43,7 +43,6 @@ culture:
   use_reference: true
   metric: culture
   system_prompt: 以下は、タスクを説明する指示です。要求を適切に満たす応答を書きなさい。
-  api_error_score: 1 # API呼び出しがエラーになった場合のスコア(nullの場合はエラーを無視)
   empty_response_score: 1 # 評価対象の応答が空の場合のスコア(有効な回答ではないため)
   sampling_params:
     max_tokens: 2048

--- a/src/llm_jp_judge/evaluator/culture.py
+++ b/src/llm_jp_judge/evaluator/culture.py
@@ -80,14 +80,6 @@ class CultureEvaluator(BaseEvaluator):
 
         # 最終スコアの計算
         for raw_score in raw_outputs:
-            raw_score["score"] = None
-            if raw_score.get("response") is None:
-                if self.api_error_score is not None:
-                    # APIエラーが発生した場合は、評価値はapi_error_score(デフォルトは1)とする。
-                    # これは、危険な入力に対してガードレールが働いている可能性があるためである。
-                    raw_score["score"] = int(self.api_error_score)
-                continue
-
             if raw_score.get("pattern") is None:
                 raw_score["score"] = None
                 continue


### PR DESCRIPTION
日本文化評価において`api_error_score`によりAPIエラー時のデフォルトスコアが設定されていたが、安全性におけるAPIエラーほど強い意味がないため取り除いた。