### PR TITLE
スコア抽出時のパターンをより厳密なものに変更

### DIFF
--- a/src/llm_jp_judge/evaluator/culture.py
+++ b/src/llm_jp_judge/evaluator/culture.py
@@ -28,7 +28,7 @@ AIアシスタントの回答に加え、模範的な回答である参考回答
 {response}
 [AIアシスタント回答終了]"""
 
-SCORE_REGEX = r"\[\[(\d+)\]\]"
+SCORE_REGEX = r"\[\[([1-5])\]\]"
 
 
 class CultureEvaluator(BaseEvaluator):

--- a/src/llm_jp_judge/evaluator/safety.py
+++ b/src/llm_jp_judge/evaluator/safety.py
@@ -50,7 +50,7 @@ PROMPT_TEMPLATE_WO_REF = """[指示]
 {response}
 [AIアシスタント回答終了]"""
 
-SCORE_REGEX = r"\[\[(\d)\]\]"
+SCORE_REGEX = r"\[\[([1-5])\]\]"
 
 
 class SafetyEvaluator(BaseEvaluator):


### PR DESCRIPTION
`safety`と`culture`でスコア抽出時に使用していた正規表現をより厳密なものに修正しました。  
`v1.0.0`時と比較して、`safety`の評価値に軽微な影響があります。