### PR TITLE
スコア抽出時に複数マッチした場合は末尾を採用するよう修正

### DIFF
--- a/src/llm_jp_judge/evaluator/base.py
+++ b/src/llm_jp_judge/evaluator/base.py
@@ -11,10 +11,12 @@ class BaseScoreExtractor(object):
         self.regex = regex
 
     def __call__(self, text):
-        m = re.search(self.regex, text)
-        if m is None:
+        score = None
+        for _score in re.findall(self.regex, text):
+            score = _score
+        if score is None:
             raise ScoreExtractionError(f"Regex '{self.regex}' did not match.")
-        return m.group(1)
+        return score
 
 
 class BaseEvaluator:

--- a/src/llm_jp_judge/evaluator/quality.py
+++ b/src/llm_jp_judge/evaluator/quality.py
@@ -54,9 +54,7 @@ class QualityScoreExtractor(object):
     def __call__(self, text):
         scores = {}
         for metric, score in re.findall(self.regex, text):
-            if metric in scores:
-                raise ScoreExtractionError("Duplicate metric")
-            scores[metric] = int(score)
+            scores[metric] = score
 
         if set(scores.keys()) != set(METRICS):
             raise ScoreExtractionError("Invalid score format")


### PR DESCRIPTION
スコア抽出時に複数マッチした場合に先頭を採用していたが、末尾を使用するように修正しました。  
`v1.0.0`と比較し、`safety`、`quality`、`mt_bench`、`ja_mt_bench`のスコアに軽微な影響があります。