### PR TITLE
client の初期化処理の修正

### DIFF
--- a/src/llm_jp_judge/client/remote.py
+++ b/src/llm_jp_judge/client/remote.py
@@ -37,12 +37,10 @@ class OpenAI(BaseClient):
         project: str | None = None,
         base_url: str | None = None,
     ):
-        super().__init__(
-            model_name=model_name,
-            max_retries=max_retries,
-            async_request_interval=async_request_interval,
-            disable_system_prompt=disable_system_prompt,
-        )
+        self.model_name = model_name
+        self.max_retries = max_retries
+        self.async_request_interval = async_request_interval
+        self.disable_system_prompt = disable_system_prompt
 
         self.client = OpenAIClient(
             api_key=api_key,
@@ -219,12 +217,10 @@ class AzureOpenAI(OpenAI):
         api_version: str | None = None,
         api_key: str | None = None,
     ):
-        super().__init__(
-            model_name=model_name,
-            max_retries=max_retries,
-            async_request_interval=async_request_interval,
-            disable_system_prompt=disable_system_prompt,
-        )
+        self.model_name = model_name
+        self.max_retries = max_retries
+        self.async_request_interval = async_request_interval
+        self.disable_system_prompt = disable_system_prompt
 
         self.client = AzureOpenAIClient(
             azure_endpoint=azure_endpoint,  # type: ignore[arg-type]
@@ -244,12 +240,10 @@ class BedrockAnthropic(AzureOpenAI):
         aws_secret_key: str | None = None,
         aws_region: str | None = None,
     ):
-        super().__init__(
-            model_name=model_name,
-            max_retries=max_retries,
-            async_request_interval=async_request_interval,
-            disable_system_prompt=disable_system_prompt,
-        )
+        self.model_name = model_name
+        self.max_retries = max_retries
+        self.async_request_interval = async_request_interval
+        self.disable_system_prompt = disable_system_prompt
 
         self.anthropic_client = AnthropicBedrockClient(
             aws_access_key=aws_access_key,


### PR DESCRIPTION
修正される問題:
- `OPENAI_API_KEY` 環境変数が設定されていない環境下で、 `AzureOpenAI` の初期化時にエラーになっていた
    - `AzureOpenAI` が親クラスである `OpenAI` の init を呼び出し、`OpenAI` のクライアントを初期化しようとしていたのが原因

解決方法:
- 各 client の初期化時に `super().__init__()` を呼び出さないように変更しました