### PR TITLE
`reasoning_effort` の設定を追加

### DIFF
--- a/src/llm_jp_judge/config/benchmark/evaluate.yaml
+++ b/src/llm_jp_judge/config/benchmark/evaluate.yaml
@@ -17,6 +17,7 @@ quality_ja:
     top_p: 0.95
     temperature: 1.0
     frequency_penalty: 0.0
+    reasoning_effort: null
 safety_ja:
   name: safety_ja
   use_reference: true
@@ -29,6 +30,7 @@ safety_ja:
     top_p: 0.95
     temperature: 1.0
     frequency_penalty: 0.0
+    reasoning_effort: null
 culture_ja:
   name: culture_ja
   use_reference: true
@@ -42,6 +44,7 @@ culture_ja:
     top_p: 0.95
     temperature: 1.0
     frequency_penalty: 0.0
+    reasoning_effort: null
 safety_borderline_ja:
   name: safety_borderline_ja
   use_reference: true
@@ -54,6 +57,7 @@ safety_borderline_ja:
     top_p: 0.95
     temperature: 1.0
     frequency_penalty: 0.0
+    reasoning_effort: null
 safety_boundary_ja:
   name: safety_boundary_ja
   metric: safety_boundary
@@ -65,6 +69,7 @@ safety_boundary_ja:
     top_p: 0.9
     temperature: 0.7
     frequency_penalty: 0.0
+    reasoning_effort: null
 mt_bench_en:
   name: mt_bench_en
   metric: mt_bench
@@ -81,6 +86,7 @@ mt_bench_en:
     top_p: null
     temperature: 0
     frequency_penalty: null
+    reasoning_effort: null
 mt_bench_ja:
   name: mt_bench_ja
   metric: mt_bench
@@ -97,3 +103,4 @@ mt_bench_ja:
     top_p: null
     temperature: 0
     frequency_penalty: null
+    reasoning_effort: null

--- a/src/llm_jp_judge/config/benchmark/generate.yaml
+++ b/src/llm_jp_judge/config/benchmark/generate.yaml
@@ -10,6 +10,7 @@ quality_ja:
     top_p: 0.95
     temperature: 1.0
     frequency_penalty: 0.0
+    reasoning_effort: null
 safety_ja:
   name: "safety_ja"
   dataset:
@@ -22,6 +23,7 @@ safety_ja:
     top_p: 0.95
     temperature: 1.0
     frequency_penalty: 0.0
+    reasoning_effort: null
 culture_ja:
   name: "culture_ja"
   dataset:
@@ -34,6 +36,7 @@ culture_ja:
     top_p: 0.95
     temperature: 1.0
     frequency_penalty: 0.0
+    reasoning_effort: null
 safety_borderline_ja:
   name: "safety_borderline_ja"
   dataset:
@@ -46,6 +49,7 @@ safety_borderline_ja:
     top_p: 0.95
     temperature: 1.0
     frequency_penalty: 0.0
+    reasoning_effort: null
 safety_boundary_ja:
   name: "safety_boundary_ja"
   dataset:
@@ -58,6 +62,7 @@ safety_boundary_ja:
     top_p: 0.9
     temperature: 0.7
     frequency_penalty: 0.0
+    reasoning_effort: null
 mt_bench_en:
   name: "mt_bench_en"
   dataset:
@@ -70,6 +75,7 @@ mt_bench_en:
     top_p: null
     temperature: 0.7
     frequency_penalty: null
+    reasoning_effort: null
   category_sampling_params: # Override the default sampling parameters for each category
     writing:
       temperature: 0.7
@@ -99,6 +105,7 @@ mt_bench_ja:
     top_p: null
     temperature: 0.7
     frequency_penalty: null
+    reasoning_effort: null
   category_sampling_params: # Override the default sampling parameters for each category
     writing:
       temperature: 0.7


### PR DESCRIPTION
タスクの設定で、 `sampling_params` に `reasoning_effort` を追加しました。

軽く動作確認した範囲では、以下のような挙動となるようです。

- vLLM で稼働している `llm-jp-3.1-13b-instruct4` （`reasoning_effort` 非対応モデル）にクエリした場合:
    - `null` (None), `low`, `medium`, `high` のいずれかを指定 → これまで通り動作
    - 上記以外の値を指定 → クエリ失敗（400 Bad Request）
- vLLM で稼働している `gpt-oss-20b` （`reasoning_effort` 対応モデル）にクエリした場合:
    - `null` (None), `low`, `medium`, `high` のいずれかを指定 → 指定された `reasoning_effort` で動作
        - ただし、`null` を指定した場合はモデルでデフォルトの `medium` が使用される
    - 上記以外の値を指定 → クエリ失敗（400 Bad Request）
- Azure OpenAI の `gpt-5.2-2025-12-11`（`reasoning_effort` 対応モデル）にクエリした場合:
    - `null` (None), `none`, `low`, `medium`, `high` のいずれかを指定 → 指定された `reasoning_effort` で動作
        - ただし、`null` を指定した場合はモデルでデフォルトの `none` が使用される
    - 上記以外の値を指定 → クエリ失敗（400 Bad Request）
