### PR TITLE
quality 評価時のエラーを修正

### DIFF
--- a/src/llm_jp_judge/evaluator/quality.py
+++ b/src/llm_jp_judge/evaluator/quality.py
@@ -43,7 +43,7 @@ class QualityEvaluator(BaseEvaluator):
             "evaluation errors",
         ]
         for raw_output in raw_outputs:
-            if raw_output.pattern is None:
+            if raw_output.pattern[0] is None:
                 scores = {metric: None for metric in metrics}
             else:
                 assert isinstance(raw_output.pattern[0], dict)


### PR DESCRIPTION
quality の評価時に、 `raw_output.pattern[0]` が None の場合（＝生成された評価結果からスコアのパターンが抽出されなかった場合）に AssertionError が発生していた問題を修正しました。