### PR TITLE
`QualityEvaluator` が出力するファイル名の修正

### DIFF
--- a/src/llm_jp_judge/evaluator/quality.py
+++ b/src/llm_jp_judge/evaluator/quality.py
@@ -58,7 +58,7 @@ class QualityEvaluator(BaseEvaluator):
                     json.dumps(raw_output.error_messages[0], ensure_ascii=False),
                 ]
             )
-        self.dashboard.log_table("quality_raw_output_table", columns=header, data=table)
+        self.dashboard.log_table(f"{self.name}_raw_output_table", columns=header, data=table)
 
     def __call__(self, responses: Sequence[QualityDatasetItem]) -> tuple[dict[str, float | None], dict[str, float]]:  # type: ignore[override]
         data: list[QualityDatasetItemForEvaluation] = []


### PR DESCRIPTION
`QualityEvaluator` が出力するファイル名が、タスク名に関わらず固定となっていたのを修正します。
- 本来は `quality_ja_raw_output_table.json` のような名前のファイルが出力されるべきですが、`quality_raw_output_table.json` という名前で出力されるようになっていました
- 他の Evaluator ではタスク名に応じた名前が付くようになっています:
  https://github.com/llm-jp/llm-jp-judge/blob/f516c082b1c2ccde9e1d869a58cdefc1dce75b63/src/llm_jp_judge/evaluator/base.py#L75
